### PR TITLE
setup.py: Specify encoding for open()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 #
 
 import imp
+import io
 
 from setuptools import setup
 
@@ -45,7 +46,7 @@ setup(
     name='upoints',
     version=_version.dotted,
     description='Modules for working with points on Earth',
-    long_description=open('README.rst').read(),
+    long_description=io.open('README.rst', encoding='UTF-8').read(),
     author='James Rowe',
     author_email='jnrowe@gmail.com',
     url='https://github.com/JNRowe/upoints/',


### PR DESCRIPTION
In environments where UTF-8 is not the default, setup.py fails to
read the README, because it contains non-ASCII names. Specifying the
encoding explicitly should fix the issue.

Test with:

    LC_ALL=C python3 setup.py